### PR TITLE
Update signal-hook to version 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,11 @@ once_cell = "1.4.1"
 
 [target.'cfg(unix)'.dependencies]
 async-io = "1.0.0"
-signal-hook = { version = "0.1.16", default-features = false }
+
+[target.'cfg(unix)'.dependencies.signal-hook]
+version = "0.3.0"
+features = ["iterator"]
+default-features = false
 
 [target.'cfg(windows)'.dependencies]
 blocking = "1.0.0"


### PR DESCRIPTION
The dependency on version v0.1.16 of signal-hook makes this library
impossible to use in a project alongside signal-hook version v0.3.0.
This is caused by an arguably incorrect dependency from signal-hook
v0.1.16 on `~1.2` of signal-hook-registry (I think it should just depend
on `^1.2` instead), however it seemed more beneficial overall to upgrade
this crate's dependency instead.

`Cargo.toml`:

```toml
[package]
name = "test-project"
version = "0.1.0"

[dependencies]
async-process = "1.0.1"
signal-hook = "0.3.0"
```

Error message when running `cargo build`:

```
error: failed to select a version for `signal-hook-registry`.
    ... required by package `signal-hook v0.1.16`
    ... which is depended on by `async-process v1.0.1`
    ... which is depended on by `test-project v0.1.0 (/home/ooesili/scratch/test-project)`
versions that meet the requirements `~1.2` are: 1.2.2, 1.2.1, 1.2.0

all possible versions conflict with previously selected packages.

  previously selected package `signal-hook-registry v1.3.0`
    ... which is depended on by `signal-hook v0.3.0`
    ... which is depended on by `test-project v0.1.0 (/home/ooesili/scratch/test-project)`

failed to select a version for `signal-hook-registry` which could resolve this conflict
```