### PR TITLE
Fix Child::output to avoid killing the subprocess early when kill_on_drop is given

### DIFF
--- a/tests/std.rs
+++ b/tests/std.rs
@@ -366,3 +366,18 @@ fn test_capture_env_at_spawn() {
         );
     })
 }
+
+#[test]
+#[cfg(unix)]
+fn child_status_preserved_with_kill_on_drop() {
+    future::block_on(async {
+        let p = Command::new("true").kill_on_drop(true).spawn().unwrap();
+
+        // Calling output, since it takes ownership of the child
+        // Child::status would work, but without special care,
+        // dropping p inside of output would kill the subprocess early,
+        // and report the wrong exit status
+        let res = p.output().await;
+        assert!(res.unwrap().status.success());
+    })
+}


### PR DESCRIPTION
Found this while trying to switch [starship](https://github.com/starship/starship) to async.
A simple case where this issue is obvious is when using `async_std::future::timeout` to short-circuit `Child::output` if it takes more than a set amount of time.

I've only written the test for unix, since that's where I am most comfortable testing.
Without the changes in `lib.rs`, the new test will fail most of the time.