### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ homepage = "https://github.com/smol-rs/async-process"
 documentation = "https://docs.rs/async-process"
 keywords = ["process", "spawn", "command", "subprocess", "child"]
 categories = ["asynchronous", "os"]
-readme = "README.md"
 
 [dependencies]
 cfg-if = "1.0"


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field.