### PR TITLE
Bump to v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.1.0
+
+- Add `into_stdio` method to `ChildStdin`, `ChildStdout`, and `ChildStderr`. (#13)
+
 # Version 1.0.2
 
 - Use `kill_on_drop` only when the last reference to `ChildGuard` is dropped.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
 name = "async-process"
+# When publishing a new version:
+# - Update CHANGELOG.md
+# - Create "v1.x.y" git tag
 version = "1.1.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -940,12 +940,12 @@ impl Command {
     }
 }
 
+/// Moves `Fd` out of non-blocking mode.
 #[cfg(unix)]
-/// Moves `Fd` out of nonblocking mode.
 fn blocking_fd(fd: std::os::unix::io::RawFd) -> io::Result<()> {
     // Helper macro to execute a system call that returns an `io::Result`.
     macro_rules! syscall {
-    ($fn: ident ( $($arg: expr),* $(,)* ) ) => {{
+        ($fn:ident ( $($arg:expr),* $(,)? ) ) => {{
             let res = unsafe { libc::$fn($($arg, )*) };
             if res == -1 {
                 return Err(std::io::Error::last_os_error());


### PR DESCRIPTION
Changes:
- Add `into_stdio` method to `ChildStdin`, `ChildStdout`, and `ChildStderr`. (#13)
