### PR TITLE
allow waiting on process exit without requiring a mutable borrow and without dropping stdin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,6 +352,30 @@ impl Child {
     /// ```
     pub fn status(&mut self) -> impl Future<Output = io::Result<ExitStatus>> {
         self.stdin.take();
+        self.status_no_drop()
+    }
+
+    /// Waits for the process to exit.
+    ///
+    /// Unlike `status`, does not drop the stdin handle. You are responsible
+    /// for avoiding deadlocks caused by the child blocking on stdin while the
+    /// parent blocks on waiting for the process to exit.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # futures_lite::future::block_on(async {
+    /// use async_process::{Command, Stdio};
+    ///
+    /// let child = Command::new("cp")
+    ///     .arg("a.txt")
+    ///     .arg("b.txt")
+    ///     .spawn()?;
+    ///
+    /// println!("exit status: {}", child.status_no_drop().await?);
+    /// # std::io::Result::Ok(()) });
+    /// ```
+    pub fn status_no_drop(&self) -> impl Future<Output = io::Result<ExitStatus>> {
         let child = self.child.clone();
 
         async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,7 +326,7 @@ impl Child {
     /// }
     /// # std::io::Result::Ok(()) });
     /// ```
-    pub fn try_status(&mut self) -> io::Result<Option<ExitStatus>> {
+    pub fn try_status(&self) -> io::Result<Option<ExitStatus>> {
         self.child.lock().unwrap().get_mut().try_wait()
     }
 


### PR DESCRIPTION
in an async program, it is pretty common to want to be able to wait on something like `read.or(write).or(exit)`, which isn't actually possible with the current api, since calling `status` closes stdin, and also requires exclusive access to the child. this kind of structure avoids the deadlock issues that `wait` in the standard library has, and so the decision to close stdin makes a bit less sense.

i added this as a new method to avoid breaking the api, but i would also not be opposed to just changing the semantics of the existing `status` method. alternate names for `status_no_drop` would also be good (i couldn't think of anything off the top of my head).