### PR TITLE
Impl From<std::process::Command> for Command

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -639,14 +639,7 @@ impl Command {
     /// let mut cmd = Command::new("ls");
     /// ```
     pub fn new<S: AsRef<OsStr>>(program: S) -> Command {
-        Command {
-            inner: std::process::Command::new(program),
-            stdin: false,
-            stdout: false,
-            stderr: false,
-            reap_on_drop: true,
-            kill_on_drop: false,
-        }
+        Self::from(std::process::Command::new(program))
     }
 
     /// Adds a single argument to pass to the program.
@@ -943,6 +936,19 @@ impl Command {
 
         let child = Child::new(self);
         async { child?.output().await }
+    }
+}
+
+impl From<std::process::Command> for Command {
+    fn from(inner: std::process::Command) -> Self {
+        Self {
+            inner,
+            stdin: false,
+            stdout: false,
+            stderr: false,
+            reap_on_drop: true,
+            kill_on_drop: false,
+        }
     }
 }
 


### PR DESCRIPTION
Allow creating Command from std::process::Command, similar to what [tokio::process::Command](https://docs.rs/tokio/latest/tokio/process/struct.Command.html#impl-From%3CCommand%3E) supports.