### PR TITLE
Port from once-cell to async-lock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ categories = ["asynchronous", "os"]
 exclude = ["/.*"]
 
 [dependencies]
+async-lock = "2.6.0"
 cfg-if = "1.0"
 event-listener = "2.4.0"
 futures-lite = "1.11.0"
-once_cell = "1.4.1"
 
 [build-dependencies]
 autocfg = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,9 +70,9 @@ use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(windows)]
 use blocking::Unblock;
 
+use async_lock::OnceCell;
 use event_listener::Event;
 use futures_lite::{future, io, prelude::*};
-use once_cell::sync::Lazy;
 
 #[doc(no_inline)]
 pub use std::process::{ExitStatus, Output, Stdio};
@@ -192,19 +192,17 @@ impl Child {
                 }
 
             } else if #[cfg(unix)] {
-                static SIGNALS: Lazy<Mutex<signal_hook::iterator::Signals>> = Lazy::new(|| {
-                    Mutex::new(
-                        signal_hook::iterator::Signals::new(&[signal_hook::consts::SIGCHLD])
-                            .expect("cannot set signal handler for SIGCHLD"),
-                    )
-                });
+                static SIGNALS: OnceCell<Mutex<signal_hook::iterator::Signals>> = OnceCell::new();
 
                 // Make sure the signal handler is registered before interacting with the process.
-                Lazy::force(&SIGNALS);
+                SIGNALS.get_or_init_blocking(|| Mutex::new(
+                    signal_hook::iterator::Signals::new(&[signal_hook::consts::SIGCHLD])
+                        .expect("cannot set signal handler for SIGCHLD"),
+                ));
 
                 // Waits for the next SIGCHLD signal.
                 fn wait_sigchld() {
-                    SIGNALS.lock().unwrap().forever().next();
+                    SIGNALS.get().expect("Signals not registered").lock().unwrap().forever().next();
                 }
 
                 // Wraps a sync I/O type into an async I/O type.
@@ -214,7 +212,10 @@ impl Child {
             }
         }
 
-        static ZOMBIES: Lazy<Mutex<Vec<std::process::Child>>> = Lazy::new(|| {
+        static ZOMBIES: OnceCell<Mutex<Vec<std::process::Child>>> = OnceCell::new();
+
+        // Make sure the thread is started.
+        ZOMBIES.get_or_init_blocking(|| {
             // Start a thread that handles SIGCHLD and notifies tasks when child processes exit.
             thread::Builder::new()
                 .name("async-process".to_string())
@@ -227,7 +228,7 @@ impl Child {
                         SIGCHLD.notify(std::usize::MAX);
 
                         // Reap zombie processes.
-                        let mut zombies = ZOMBIES.lock().unwrap();
+                        let mut zombies = ZOMBIES.get().unwrap().lock().unwrap();
                         let mut i = 0;
                         while i < zombies.len() {
                             if let Ok(None) = zombies[i].try_wait() {
@@ -243,9 +244,6 @@ impl Child {
             Mutex::new(Vec::new())
         });
 
-        // Make sure the thread is started.
-        Lazy::force(&ZOMBIES);
-
         // When the last reference to the child process is dropped, push it into the zombie list.
         impl Drop for ChildGuard {
             fn drop(&mut self) {
@@ -253,7 +251,7 @@ impl Child {
                     self.get_mut().kill().ok();
                 }
                 if self.reap_on_drop {
-                    let mut zombies = ZOMBIES.lock().unwrap();
+                    let mut zombies = ZOMBIES.get().unwrap().lock().unwrap();
                     if let Ok(None) = self.get_mut().try_wait() {
                         zombies.push(self.inner.take().unwrap());
                     }


### PR DESCRIPTION
See [here](https://github.com/smol-rs/smol/pull/241#issuecomment-1328007424). We need to remove all usage of `once_cell` here and replace it with `async-lock`. This PR largely replaces usage of  `once_cell::Lazy` with `async_lock::OnceCell`.