### PR TITLE
Port to windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,11 @@ default-features = false
 [target.'cfg(windows)'.dependencies]
 blocking = "1.0.0"
 
-[target.'cfg(windows)'.dependencies.winapi]
-version = "0.3.9"
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.42"
 default-features = false
 features = [
-  "winbase",
-  "winnt"
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_System_WindowsProgramming" 
 ]

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -385,7 +385,7 @@ fn child_status_preserved_with_kill_on_drop() {
 #[cfg(windows)]
 fn child_as_raw_handle() {
     use std::os::windows::io::AsRawHandle;
-    use winapi::um::processthreadsapi::GetProcessId;
+    use windows_sys::Win32::System::Threading::GetProcessId;
 
     future::block_on(async {
         let p = Command::new("cmd.exe")


### PR DESCRIPTION
The ecosystem is, by and large, migrating away from `winapi` and moving towards `windows-sys`. This PR ports the current Windows implementation of process waiting from `winapi` to `windows-sys`.