### PR TITLE
Release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 1.6.0
+
+- Switch from `winapi` to `windows-sys` (#27)
+- Remove the dependency on the `once_cell` crate to restore the MSRV (#26)
+- Fix build failure with minimal-versions (#28)
+
 # Version 1.5.0
 
 - Implement `AsRawFd` for `ChildStd*` on Unix (#23)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-process"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.5.0"
+version = "1.6.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.46"
@@ -41,5 +41,5 @@ default-features = false
 features = [
     "Win32_Foundation",
     "Win32_System_Threading",
-    "Win32_System_WindowsProgramming" 
+    "Win32_System_WindowsProgramming"
 ]


### PR DESCRIPTION
Changes:
- Switch from `winapi` to `windows-sys` (#27)
- Remove the dependency on the `once_cell` crate to restore the MSRV (#26)
- Fix build failure with minimal-versions (#28)