### PR TITLE
Add windows::CommandExt::raw_arg on Rust 1.62+

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,9 @@ fn main() {
         }
     };
 
+    if !cfg.probe_rustc_version(1, 62) {
+        autocfg::emit("async_process_no_windows_raw_arg");
+    }
     if !cfg.probe_rustc_version(1, 63) {
         autocfg::emit("async_process_no_io_safety");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,6 +520,7 @@ impl AsRawFd for ChildStdin {
     }
 }
 
+/// **Note:** This implementation is only available on Rust 1.63+.
 #[cfg(all(not(async_process_no_io_safety), unix))]
 impl AsFd for ChildStdin {
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -527,6 +528,7 @@ impl AsFd for ChildStdin {
     }
 }
 
+/// **Note:** This implementation is only available on Rust 1.63+.
 #[cfg(all(not(async_process_no_io_safety), unix))]
 impl TryFrom<ChildStdin> for OwnedFd {
     type Error = io::Error;
@@ -604,6 +606,7 @@ impl AsRawFd for ChildStdout {
     }
 }
 
+/// **Note:** This implementation is only available on Rust 1.63+.
 #[cfg(all(not(async_process_no_io_safety), unix))]
 impl AsFd for ChildStdout {
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -611,6 +614,7 @@ impl AsFd for ChildStdout {
     }
 }
 
+/// **Note:** This implementation is only available on Rust 1.63+.
 #[cfg(all(not(async_process_no_io_safety), unix))]
 impl TryFrom<ChildStdout> for OwnedFd {
     type Error = io::Error;
@@ -677,6 +681,7 @@ impl AsRawFd for ChildStderr {
     }
 }
 
+/// **Note:** This implementation is only available on Rust 1.63+.
 #[cfg(all(not(async_process_no_io_safety), unix))]
 impl AsFd for ChildStderr {
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -684,6 +689,7 @@ impl AsFd for ChildStderr {
     }
 }
 
+/// **Note:** This implementation is only available on Rust 1.63+.
 #[cfg(all(not(async_process_no_io_safety), unix))]
 impl TryFrom<ChildStderr> for OwnedFd {
     type Error = io::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,10 @@ pub mod unix;
 #[cfg(windows)]
 pub mod windows;
 
+mod sealed {
+    pub trait Sealed {}
+}
+
 /// An event delivered every time the SIGCHLD signal occurs.
 static SIGCHLD: Event = Event::new();
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -7,7 +7,10 @@ use std::os::unix::process::CommandExt as _;
 use crate::Command;
 
 /// Unix-specific extensions to the [`Command`] builder.
-pub trait CommandExt {
+///
+/// This trait is sealed: it cannot be implemented outside `async-process`.
+/// This is so that future additional methods are not breaking changes.
+pub trait CommandExt: crate::sealed::Sealed {
     /// Sets the child process's user ID. This translates to a
     /// `setuid` call in the child process. Failure in the `setuid`
     /// call will cause the spawn to fail.
@@ -88,6 +91,7 @@ pub trait CommandExt {
         S: AsRef<OsStr>;
 }
 
+impl crate::sealed::Sealed for Command {}
 impl CommandExt for Command {
     fn uid(&mut self, id: u32) -> &mut Command {
         self.inner.uid(id);

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -6,7 +6,10 @@ use std::os::windows::process::CommandExt as _;
 use crate::{Child, Command};
 
 /// Windows-specific extensions to the [`Command`] builder.
-pub trait CommandExt {
+///
+/// This trait is sealed: it cannot be implemented outside `async-process`.
+/// This is so that future additional methods are not breaking changes.
+pub trait CommandExt: crate::sealed::Sealed {
     /// Sets the [process creation flags][1] to be passed to `CreateProcess`.
     ///
     /// These will always be ORed with `CREATE_UNICODE_ENVIRONMENT`.
@@ -15,6 +18,7 @@ pub trait CommandExt {
     fn creation_flags(&mut self, flags: u32) -> &mut Command;
 }
 
+impl crate::sealed::Sealed for Command {}
 impl CommandExt for Command {
     fn creation_flags(&mut self, flags: u32) -> &mut Command {
         self.inner.creation_flags(flags);


### PR DESCRIPTION
This adds windows::CommandExt::raw_arg that internally calls [std::os::windows::process::CommandExt::raw_arg](https://doc.rust-lang.org/std/os/windows/process/trait.CommandExt.html#tymethod.raw_arg) on Rust 1.62+

Closes #24

This also seals CommandExt trait. This is technically a breaking change, but we follow the standard library's decision that sealing CommandExt is fine.
https://github.com/rust-lang/rust/commit/bfd1ccfb271f03aa85488408c3b03a15ad8d7c7f

Closes #6