### PR TITLE
feat: Add a cleanup_zombies future for reaping zombie processes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ rustix = { version = "0.36", default-features = false, features = ["std", "fs"] 
 
 [target.'cfg(unix)'.dependencies.signal-hook]
 version = "0.3.0"
-features = ["iterator"]
 default-features = false
 
 [target.'cfg(windows)'.dependencies]
@@ -43,3 +42,6 @@ features = [
     "Win32_System_Threading",
     "Win32_System_WindowsProgramming"
 ]
+
+[dev-dependencies]
+async-executor = "1.5.0"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ spawned child processes to exit and then calls the `wait()` syscall to clean up 
 processes. This is unlike the `process` API in the standard library, where dropping a running
 `Child` leaks its resources.
 
+However, note that you can reap zombie processes without spawning the "async-process" thread
+by calling the `cleanup_zombies` method. The "async-process" method is therefore only spawned
+if no other thread calls `cleanup_zombies`.
+
 This crate uses [`async-io`] for async I/O on Unix-like systems and [`blocking`] for async I/O
 on Windows.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ processes. This is unlike the `process` API in the standard library, where dropp
 `Child` leaks its resources.
 
 However, note that you can reap zombie processes without spawning the "async-process" thread
-by calling the `cleanup_zombies` method. The "async-process" method is therefore only spawned
+by calling the `cleanup_zombies` method. The "async-process" thread is therefore only spawned
 if no other thread calls `cleanup_zombies`.
 
 This crate uses [`async-io`] for async I/O on Unix-like systems and [`blocking`] for async I/O

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! `Child` leaks its resources.
 //!
 //! However, note that you can reap zombie processes without spawning the "async-process" thread
-//! by calling the [`cleanup_zombies`] method. The "async-process" method is therefore only spawned
+//! by calling the [`cleanup_zombies`] method. The "async-process" thread is therefore only spawned
 //! if no other thread calls [`cleanup_zombies`].
 //!
 //! This crate uses [`async-io`] for async I/O on Unix-like systems and [`blocking`] for async I/O

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,11 +230,6 @@ cfg_if::cfg_if! {
                 use std::ffi::c_void;
                 use std::os::windows::io::AsRawHandle;
 
-                // Called when a child exits.
-                unsafe extern "system" fn callback(_: *mut c_void, _: BOOLEAN) {
-                    Reactor::get().pipe.event.notify_additional(1);
-                }
-
                 use windows_sys::Win32::{
                     System::{
                         Threading::{RegisterWaitForSingleObject, WT_EXECUTEINWAITTHREAD, WT_EXECUTEONLYONCE},
@@ -242,6 +237,11 @@ cfg_if::cfg_if! {
                     },
                     Foundation::{BOOLEAN, HANDLE},
                 };
+
+                // Called when a child exits.
+                unsafe extern "system" fn callback(_: *mut c_void, _: BOOLEAN) {
+                    Reactor::get().pipe.event.notify_additional(1);
+                }
 
                 // Register this child process to invoke `callback` on exit.
                 let mut wait_object = 0;

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -45,22 +45,6 @@ fn smoke_failure() {
 }
 
 #[test]
-fn wait() {
-    future::block_on({
-        async_process::cleanup_zombies(async {
-            let p = if cfg!(target_os = "windows") {
-                Command::new("timeout").args(&["/t", "3"]).spawn()
-            } else {
-                Command::new("sleep").arg("3").spawn()
-            };
-            assert!(p.is_ok());
-            let mut p = p.unwrap();
-            assert!(p.status().await.unwrap().success());
-        })
-    });
-}
-
-#[test]
 fn exit_reported_right() {
     future::block_on(async {
         let p = if cfg!(target_os = "windows") {

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -45,6 +45,22 @@ fn smoke_failure() {
 }
 
 #[test]
+fn wait() {
+    future::block_on({
+        async_process::cleanup_zombies(async {
+            let p = if cfg!(target_os = "windows") {
+                Command::new("timeout").args(&["/t", "3"]).spawn()
+            } else {
+                Command::new("sleep").arg("3").spawn()
+            };
+            assert!(p.is_ok());
+            let mut p = p.unwrap();
+            assert!(p.status().await.unwrap().success());
+        })
+    });
+}
+
+#[test]
 fn exit_reported_right() {
     future::block_on(async {
         let p = if cfg!(target_os = "windows") {

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -22,6 +22,22 @@ fn smoke() {
 }
 
 #[test]
+fn smoke_with_driver() {
+    future::block_on({
+        async_process::cleanup_zombies(async {
+            let p = if cfg!(target_os = "windows") {
+                Command::new("cmd").args(&["/C", "exit 0"]).spawn()
+            } else {
+                Command::new("true").spawn()
+            };
+            assert!(p.is_ok());
+            let mut p = p.unwrap();
+            assert!(p.status().await.unwrap().success());
+        })
+    })
+}
+
+#[test]
 fn smoke_failure() {
     assert!(Command::new("if-this-is-a-binary-then-the-world-has-ended")
         .spawn()


### PR DESCRIPTION
This PR adds a new `cleanup_zombies` future. I'm open to bikeshedding the name. This future asynchronously waits for the `SIGCHLD` signal and then processes those zombie threads by waiting on them. This is similar to the function of the `async-process` thread, and this future aims to allow users to run the reaping function on their own threads. The goal is similar to the `block_on` function from `async_io`.

This started out as an implementation of #7, but while I was implementing it I realized that this could be possible.

This PR also contains a rework of the internal `async-process` reactor to make this possible.

Closes #7