### PR TITLE
v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 1.7.0
+
+- Replace direct dependency on libc with rustix. (#31)
+- Reduce the number of syscalls used in the `into_stdio` method. (#31)
+- Add windows::CommandExt::raw_arg on Rust 1.62+. (#32)
+- Update windows-sys to 0.48. (#39)
+
 # Version 1.6.0
 
 - Switch from `winapi` to `windows-sys` (#27)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-process"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.6.0"
+version = "1.7.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.48"


### PR DESCRIPTION
- Replace direct dependency on libc with rustix. (#31)
- Reduce the number of syscalls used in the `into_stdio` method. (#31)
- Add windows::CommandExt::raw_arg on Rust 1.62+. (#32)
- Update windows-sys to 0.48. (#39)