### PR TITLE
Use async-signal instead of signal-hook

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,8 @@ futures-lite = "1.11.0"
 
 [target.'cfg(unix)'.dependencies]
 async-io = "1.8"
+async-signal = "0.2.0"
 rustix = { version = "0.37", default-features = false, features = ["std", "fs"] }
-
-[target.'cfg(unix)'.dependencies.signal-hook]
-version = "0.3.0"
-features = ["iterator"]
-default-features = false
 
 [target.'cfg(windows)'.dependencies]
 blocking = "1.0.0"


### PR DESCRIPTION
Rather than using a locked `signal_hook::Signals` type, this PR uses the new `async-signal` crate to wait for the SIGCHLD signal. This implementation will use more optimized implementations of signal waiting on other platforms (such as `signalfd` on Linux).

Ideally, this will help us avoid needing to block a separate thread with the signal waiting in the future.

cc #7 