### PR TITLE
Add a way to run without the async-process thread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ async-signal = "0.2.0"
 rustix = { version = "0.38", default-features = false, features = ["std", "fs"] }
 
 [target.'cfg(windows)'.dependencies]
+async-channel = "1.9.0"
 blocking = "1.0.0"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
@@ -37,4 +38,5 @@ features = [
 ]
 
 [dev-dependencies]
+async-executor = "1.5.1"
 async-io = "1.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1323,6 +1323,11 @@ mod test {
             cmd
         }
 
+        #[cfg(unix)]
+        const OUTPUT: &[u8] = b"hello\n";
+        #[cfg(windows)]
+        const OUTPUT: &[u8] = b"hello\r\n";
+
         future::block_on(async {
             // Thread should not be spawned off the bat.
             assert!(!is_thread_spawned());
@@ -1338,7 +1343,7 @@ mod test {
             }
             .or(async {
                 let output = command().output().await.unwrap();
-                assert_eq!(output.stdout, b"hello\n");
+                assert_eq!(output.stdout, OUTPUT);
             })
             .await;
             assert!(!is_thread_spawned());
@@ -1357,7 +1362,7 @@ mod test {
             })
             .or(async {
                 let output = command().output().await.unwrap();
-                assert_eq!(output.stdout, b"hello\n");
+                assert_eq!(output.stdout, OUTPUT);
             })
             .await;
             assert!(!is_thread_spawned());
@@ -1372,7 +1377,7 @@ mod test {
             }
             .or(async {
                 let output = command().output().await.unwrap();
-                assert_eq!(output.stdout, b"hello\n");
+                assert_eq!(output.stdout, OUTPUT);
             })
             .await;
             assert!(!is_thread_spawned());
@@ -1385,7 +1390,7 @@ mod test {
             // We should now be able to poll the process future independently, it will spawn the
             // thread.
             let output = command().output().await.unwrap();
-            assert_eq!(output.stdout, b"hello\n");
+            assert_eq!(output.stdout, OUTPUT);
             assert!(is_thread_spawned());
         });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,9 @@ impl Reaper {
     #[cold]
     fn start_driver_thread(&'static self) {
         #[cfg(test)]
-        DRIVER_THREAD_SPAWNED.store(true, Ordering::SeqCst);
+        DRIVER_THREAD_SPAWNED
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .unwrap_or_else(|_| unreachable!("Driver thread already spawned"));
 
         thread::Builder::new()
             .name("async-process".to_string())

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -22,6 +22,25 @@ fn smoke() {
 }
 
 #[test]
+fn smoke_driven() {
+    future::block_on(
+        async {
+            async_process::driver().await;
+        }
+        .or(async {
+            let p = if cfg!(target_os = "windows") {
+                Command::new("cmd").args(["/C", "exit 0"]).spawn()
+            } else {
+                Command::new("true").spawn()
+            };
+            assert!(p.is_ok());
+            let mut p = p.unwrap();
+            assert!(p.status().await.unwrap().success());
+        }),
+    )
+}
+
+#[test]
 fn smoke_failure() {
     assert!(Command::new("if-this-is-a-binary-then-the-world-has-ended")
         .spawn()


### PR DESCRIPTION
I know I said that I wouldn't add any more features, but I think this is important enough.

Right now, a thread called "async-process" is responsible for listening for SIGCHLD and reaping zombie processes. This listens for the SIGCHLD signal in Unix and uses a channel connected to the waitable handle on Windows. While this works, we can do better. Through async-signal, the signal was already asynchronous on Unix; we were already just using async_io::block_on to wait on the signal. After swapping out the channel used on Windows with async-channel, the process reaping function "reap" can be reimplemented as a fully asynchronous future.

From here we must make sure this future is being polled at all times. To facilitate this, a function named "driver()" is added to the public API. This future acquires a lock on the reaper structure and calls the "reap()" future indefinitely. Multiple drivers can be created at once; they will just wait forever on this lock. This future is intended to be spawned onto an executor and left to run forever, making sure all child processes are signalled whenever necessary. If no tasks are running the driver future, the "async-process" thread is spawned and runs the "reap()" future itself.

I've added the following controls to make sure that this system is robust:

- If a "driver" task is dropped, another "driver" task will acquire the lock and keep the reaper active.
- Before being dropped, the task checks to see if it is the last driver. If it is, it will spawn the "async-process" thread to be the driver.
- When a Child is being created, it checks if there are any active drivers. If there are none, it spawns the "async-process" thread itself.
- One concern is that the driver future wil try to spawn the "async-process" thread as the application exits and the task is being dropped, which will be unnecessary and lead to slower shutdowns. To prevent this, the future checks to see if there are any extant `Child` instances (a new refcount is added to Reaper to facilitate this). If there are none, and if there are no zombie processes, it does not spawn the additional thread.
- Someone can still `mem::forget()` the driver thread. This does not lead to undefined behavior and just leads to processes being left dangling. At this point they're asking for wacky behavior.

This strategy might also be viable for `async-io`, if we want to try to avoid needing to spawn the additional thread there as well.

Closes #7
cc smol-rs/async-io#40