### PR TITLE
v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 1.8.0
+
+- Move from `signal-hook` to the `async-signal` crate. (#42)
+- Reorganize the internals of this crate to be more coherent. (#46)
+- Bump to `event-listener` v3.0.0. (#43)
+
 # Version 1.7.0
 
 - Replace direct dependency on libc with rustix. (#31)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-process"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.7.0"
+version = "1.8.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.63"


### PR DESCRIPTION
- Move from `signal-hook` to the `async-signal` crate. (#42)
- Reorganize the internals of this crate to be more coherent. (#46)
- Bump to `event-listener` v3.0.0. (#43)