### PR TITLE
Migrate to Rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "async-process"
 # - Create "v1.x.y" git tag
 version = "1.8.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.63"
 description = "Async interface for working with processes"
 license = "Apache-2.0 OR MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,8 +67,6 @@ use std::thread;
 #[cfg(unix)]
 use async_io::Async;
 #[cfg(unix)]
-use std::convert::{TryFrom, TryInto};
-#[cfg(unix)]
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
 
 #[cfg(windows)]


### PR DESCRIPTION
Our MSRV (1.63) is higher than 1.56 that Rust 2021 was stabilized.