### PR TITLE
v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 2.0.0
+
+- **Breaking:** Remove the `pre_exec` extension function on Unix. It is still available through the `From<std::process::Command>` implementation on `Command`. (#54)
+- Add the `driver()` function, which allows the processes to be driven without a separate thread. (#52)
+- Bump `async-io` to v2.0.0 and `async-channel` to v2.0.0. (#60)
+
 # Version 1.8.1
 
 - Bump `async-signal` to v0.2.3. (#56)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "async-process"
 # When publishing a new version:
 # - Update CHANGELOG.md
-# - Create "v1.x.y" git tag
-version = "1.8.1"
+# - Create "v2.x.y" git tag
+version = "2.0.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- **Breaking:** Remove the `pre_exec` extension function on Unix. It is still available through the `From<std::process::Command>` implementation on `Command`. (#54)
- Add the `driver()` function, which allows the processes to be driven without a separate thread. (#52)
- Bump `async-io` to v2.0.0 and `async-channel` to v2.0.0. (#60)
