### PR TITLE
Add a backend for waitable handles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
         if: startsWith(matrix.rust, 'nightly')
         run: cargo check -Z features=dev_dep
       - run: cargo test
+      - run: cargo test
+        env:
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} --cfg async_process_force_signal_backend
 
   msrv:
     runs-on: ${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,19 @@ async-lock = "3.0.0"
 cfg-if = "1.0"
 event-listener = "5.1.0"
 futures-lite = "2.0.0"
+tracing = { version = "0.1.40", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 async-io = "2.1.0"
-async-signal = "0.2.3"
 rustix = { version = "0.38", default-features = false, features = ["std", "fs"] }
+
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+async-channel = "2.0.0"
+async-task = "4.7.0"
+
+[target.'cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))'.dependencies]
+async-signal = "0.2.3"
+rustix = { version = "0.38", default-features = false, features = ["std", "fs", "process"] }
 
 [target.'cfg(windows)'.dependencies]
 async-channel = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ tracing = { version = "0.1.40", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 async-io = "2.1.0"
+async-signal = "0.2.3"
 rustix = { version = "0.38", default-features = false, features = ["std", "fs"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
@@ -30,7 +31,6 @@ async-channel = "2.0.0"
 async-task = "4.7.0"
 
 [target.'cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))'.dependencies]
-async-signal = "0.2.3"
 rustix = { version = "0.38", default-features = false, features = ["std", "fs", "process"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,18 @@ use futures_lite::{future, io, prelude::*};
 #[doc(no_inline)]
 pub use std::process::{ExitStatus, Output, Stdio};
 
-#[path = "reaper/signal.rs"]
-mod reaper;
+cfg_if::cfg_if! {
+    if #[cfg(any(
+        target_os = "linux",
+        target_os = "android"
+    ))] {
+        #[path = "reaper/wait.rs"]
+        mod reaper;
+    } else {
+        #[path = "reaper/signal.rs"]
+        mod reaper;
+    }
+}
 
 #[cfg(unix)]
 pub mod unix;

--- a/src/reaper/mod.rs
+++ b/src/reaper/mod.rs
@@ -1,0 +1,221 @@
+//! The underlying system reaper.
+//!
+//! There are two backends:
+//!
+//! - signal, which waits for SIGCHLD.
+//! - wait, which waits directly on a process handle.
+//!
+//! "wait" is preferred, but is not available on all supported Linuxes. So we
+//! test to see if pidfd is supported first. If it is, we use wait. If not, we use
+//! signal.
+
+#![allow(irrefutable_let_patterns)]
+
+/// Enable the waiting reaper.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+macro_rules! cfg_wait {
+    ($($tt:tt)*) => {$($tt)*};
+}
+
+/// Enable the waiting reaper.
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+macro_rules! cfg_wait {
+    ($($tt:tt)*) => {};
+}
+
+/// Enable signals.
+macro_rules! cfg_signal {
+    ($($tt:tt)*) => {$($tt)*};
+}
+
+cfg_wait! {
+    mod wait;
+}
+
+cfg_signal! {
+    mod signal;
+}
+
+use std::io;
+use std::sync::Mutex;
+
+/// The underlying system reaper.
+pub(crate) enum Reaper {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    /// The reaper based on the wait backend.
+    Wait(wait::Reaper),
+
+    /// The reaper based on the signal backend.
+    Signal(signal::Reaper),
+}
+
+/// The wrapper around a child.
+pub(crate) enum ChildGuard {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    /// The child guard based on the wait backend.
+    Wait(wait::ChildGuard),
+
+    /// The child guard based on the signal backend.
+    Signal(signal::ChildGuard),
+}
+
+/// A lock on the reaper.
+pub(crate) enum Lock {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    /// The wait-based reaper needs no lock.
+    Wait,
+
+    /// The lock for the signal-based reaper.
+    Signal(signal::Lock),
+}
+
+impl Reaper {
+    /// Create a new reaper.
+    pub(crate) fn new() -> Self {
+        cfg_wait! {
+            if wait::available() && !cfg!(async_process_force_signal_backend) {
+                return Self::Wait(wait::Reaper::new());
+            }
+        }
+
+        // Return the signal-based reaper.
+        cfg_signal! {
+            return Self::Signal(signal::Reaper::new());
+        }
+
+        #[allow(unreachable_code)]
+        {
+            panic!("neither the signal backend nor the waiter backend is available")
+        }
+    }
+
+    /// Lock the driver thread.
+    ///
+    /// This makes it so only one thread can reap at once.
+    pub(crate) async fn lock(&'static self) -> Lock {
+        cfg_wait! {
+            if let Self::Wait(_this) = self {
+                // No locking needed.
+                return Lock::Wait;
+            }
+        }
+
+        cfg_signal! {
+            if let Self::Signal(this) = self {
+                // We need to lock.
+                return Lock::Signal(this.lock().await);
+            }
+        }
+
+        unreachable!()
+    }
+
+    /// Reap zombie processes forever.
+    pub(crate) async fn reap(&'static self, lock: Lock) -> ! {
+        cfg_wait! {
+            if let (Self::Wait(this), Lock::Wait) = (self, &lock) {
+                return this.reap().await;
+            }
+        }
+
+        cfg_signal! {
+            if let (Self::Signal(this), Lock::Signal(lock)) = (self, lock) {
+                return this.reap(lock).await;
+            }
+        }
+
+        unreachable!()
+    }
+
+    /// Register a child into this reaper.
+    pub(crate) fn register(&'static self, child: std::process::Child) -> io::Result<ChildGuard> {
+        cfg_wait! {
+            if let Self::Wait(this) = self {
+                return this.register(child).map(ChildGuard::Wait);
+            }
+        }
+
+        cfg_signal! {
+            if let Self::Signal(this) = self {
+                return this.register(child).map(ChildGuard::Signal);
+            }
+        }
+
+        unreachable!()
+    }
+
+    /// Wait for the inner child to complete.
+    pub(crate) async fn status(
+        &'static self,
+        child: &Mutex<crate::ChildGuard>,
+    ) -> io::Result<std::process::ExitStatus> {
+        cfg_wait! {
+            if let Self::Wait(this) = self {
+                return this.status(child).await;
+            }
+        }
+
+        cfg_signal! {
+            if let Self::Signal(this) = self {
+                return this.status(child).await;
+            }
+        }
+
+        unreachable!()
+    }
+
+    /// Do we have any registered zombie processes?
+    pub(crate) fn has_zombies(&'static self) -> bool {
+        cfg_wait! {
+            if let Self::Wait(this) = self {
+                return this.has_zombies();
+            }
+        }
+
+        cfg_signal! {
+            if let Self::Signal(this) = self {
+                return this.has_zombies();
+            }
+        }
+
+        unreachable!()
+    }
+}
+
+impl ChildGuard {
+    /// Get a reference to the inner process.
+    pub(crate) fn get_mut(&mut self) -> &mut std::process::Child {
+        cfg_wait! {
+            if let Self::Wait(this) = self {
+                return this.get_mut();
+            }
+        }
+
+        cfg_signal! {
+            if let Self::Signal(this) = self {
+                return this.get_mut();
+            }
+        }
+
+        unreachable!()
+    }
+
+    /// Start reaping this child process.
+    pub(crate) fn reap(&mut self, reaper: &'static Reaper) {
+        cfg_wait! {
+            if let (Self::Wait(this), Reaper::Wait(reaper)) = (&mut *self, reaper) {
+                this.reap(reaper);
+                return;
+            }
+        }
+
+        cfg_signal! {
+            if let (Self::Signal(this), Reaper::Signal(reaper)) = (self, reaper) {
+                this.reap(reaper);
+                return;
+            }
+        }
+
+        unreachable!()
+    }
+}

--- a/src/reaper/signal.rs
+++ b/src/reaper/signal.rs
@@ -1,0 +1,234 @@
+//! A version of the reaper that waits for a signal to check for process progress.
+
+use async_lock::{Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard};
+use event_listener::Event;
+use futures_lite::future;
+
+use std::io;
+use std::mem;
+use std::sync::Mutex;
+
+pub(crate) type Lock = AsyncMutexGuard<'static, ()>;
+
+/// The zombie process reaper.
+pub(crate) struct Reaper {
+    /// An event delivered every time the SIGCHLD signal occurs.
+    sigchld: Event,
+
+    /// The list of zombie processes.
+    zombies: Mutex<Vec<std::process::Child>>,
+
+    /// The pipe that delivers signal notifications.
+    pipe: Pipe,
+
+    /// Locking this mutex indicates that we are polling the SIGCHLD event.
+    driver_guard: AsyncMutex<()>,
+}
+
+impl Reaper {
+    /// Create a new reaper.
+    pub(crate) fn new() -> Self {
+        Reaper {
+            sigchld: Event::new(),
+            zombies: Mutex::new(Vec::new()),
+            pipe: Pipe::new().expect("cannot create SIGCHLD pipe"),
+            driver_guard: AsyncMutex::new(()),
+        }
+    }
+
+    /// Lock the driver thread.
+    pub(crate) async fn lock(&self) -> AsyncMutexGuard<'_, ()> {
+        self.driver_guard.lock().await
+    }
+
+    /// Reap zombie processes forever.
+    pub(crate) async fn reap(&'static self, _driver_guard: async_lock::MutexGuard<'_, ()>) -> ! {
+        loop {
+            // Wait for the next SIGCHLD signal.
+            self.pipe.wait().await;
+
+            // Notify all listeners waiting on the SIGCHLD event.
+            self.sigchld.notify(std::usize::MAX);
+
+            // Reap zombie processes, but make sure we don't hold onto the lock for too long!
+            let mut zombies = mem::take(&mut *self.zombies.lock().unwrap());
+            let mut i = 0;
+            'reap_zombies: loop {
+                for _ in 0..50 {
+                    if i >= zombies.len() {
+                        break 'reap_zombies;
+                    }
+
+                    if let Ok(None) = zombies[i].try_wait() {
+                        i += 1;
+                    } else {
+                        zombies.swap_remove(i);
+                    }
+                }
+
+                // Be a good citizen; yield if there are a lot of processes.
+                //
+                // After we yield, check if there are more zombie processes.
+                future::yield_now().await;
+                zombies.append(&mut self.zombies.lock().unwrap());
+            }
+
+            // Put zombie processes back.
+            self.zombies.lock().unwrap().append(&mut zombies);
+        }
+    }
+
+    /// Register a process with this reaper.
+    pub(crate) fn register(&'static self, child: std::process::Child) -> io::Result<ChildGuard> {
+        self.pipe.register(&child)?;
+        Ok(ChildGuard { inner: Some(child) })
+    }
+
+    /// Wait for an event to occur for a child process.
+    pub(crate) async fn status(
+        &'static self,
+        child: &Mutex<crate::ChildGuard>,
+    ) -> io::Result<std::process::ExitStatus> {
+        loop {
+            // Wait on the child process.
+            if let Some(status) = child.lock().unwrap().get_mut().try_wait()? {
+                return Ok(status);
+            }
+
+            // Start listening.
+            event_listener::listener!(self.sigchld => listener);
+
+            // Try again.
+            if let Some(status) = child.lock().unwrap().get_mut().try_wait()? {
+                return Ok(status);
+            }
+
+            // Wait on the listener.
+            listener.await;
+        }
+    }
+
+    /// Do we have any registered zombie processes?
+    pub(crate) fn has_zombies(&'static self) -> bool {
+        !self
+            .zombies
+            .lock()
+            .unwrap_or_else(|x| x.into_inner())
+            .is_empty()
+    }
+}
+
+/// The wrapper around the child.
+pub(crate) struct ChildGuard {
+    inner: Option<std::process::Child>,
+}
+
+impl ChildGuard {
+    /// Get a mutable reference to the inner child.
+    pub(crate) fn get_mut(&mut self) -> &mut std::process::Child {
+        self.inner.as_mut().unwrap()
+    }
+
+    /// Begin the reaping process for this child.
+    pub(crate) fn reap(&mut self, reaper: &'static Reaper) {
+        let mut zombies = reaper.zombies.lock().unwrap();
+        if let Ok(None) = self.get_mut().try_wait() {
+            zombies.push(self.inner.take().unwrap());
+        }
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(windows)] {
+        use async_channel::{Sender, Receiver, bounded};
+        use std::ffi::c_void;
+        use std::os::windows::io::AsRawHandle;
+
+        use windows_sys::Win32::{
+            Foundation::{BOOLEAN, HANDLE},
+            System::Threading::{
+                RegisterWaitForSingleObject, INFINITE, WT_EXECUTEINWAITTHREAD, WT_EXECUTEONLYONCE,
+            },
+        };
+
+        /// Waits for the next SIGCHLD signal.
+        struct Pipe {
+            /// The sender channel for the SIGCHLD signal.
+            sender: Sender<()>,
+
+            /// The receiver channel for the SIGCHLD signal.
+            receiver: Receiver<()>,
+        }
+
+        impl Pipe {
+            /// Creates a new pipe.
+            fn new() -> io::Result<Pipe> {
+                let (sender, receiver) = bounded(1);
+                Ok(Pipe {
+                    sender,
+                    receiver
+                })
+            }
+
+            /// Waits for the next SIGCHLD signal.
+            async fn wait(&self) {
+                self.receiver.recv().await.ok();
+            }
+
+            /// Register a process object into this pipe.
+            fn register(&self, child: &std::process::Child) -> io::Result<()> {
+                // Called when a child exits.
+                unsafe extern "system" fn callback(_: *mut c_void, _: BOOLEAN) {
+                    crate::Reaper::get().sys.pipe.sender.try_send(()).ok();
+                }
+
+                // Register this child process to invoke `callback` on exit.
+                let mut wait_object = 0;
+                let ret = unsafe {
+                    RegisterWaitForSingleObject(
+                        &mut wait_object,
+                        child.as_raw_handle() as HANDLE,
+                        Some(callback),
+                        std::ptr::null_mut(),
+                        INFINITE,
+                        WT_EXECUTEINWAITTHREAD | WT_EXECUTEONLYONCE,
+                    )
+                };
+
+                if ret == 0 {
+                    Err(io::Error::last_os_error())
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    } else if #[cfg(unix)] {
+        use async_signal::{Signal, Signals};
+        use futures_lite::prelude::*;
+
+        /// Waits for the next SIGCHLD signal.
+        struct Pipe {
+            /// The iterator over SIGCHLD signals.
+            signals: Signals,
+        }
+
+        impl Pipe {
+            /// Creates a new pipe.
+            fn new() -> io::Result<Pipe> {
+                Ok(Pipe {
+                    signals: Signals::new(Some(Signal::Child))?,
+                })
+            }
+
+            /// Waits for the next SIGCHLD signal.
+            async fn wait(&self) {
+                (&self.signals).next().await;
+            }
+
+            /// Register a process object into this pipe.
+            fn register(&self, _child: &std::process::Child) -> io::Result<()> {
+                Ok(())
+            }
+        }
+    }
+}

--- a/src/reaper/wait.rs
+++ b/src/reaper/wait.rs
@@ -1,0 +1,190 @@
+//! A version of the reaper that waits on some polling primitive.
+//!
+//! This uses:
+//!
+//! - pidfd on Linux/Android
+
+use async_channel::{Receiver, Sender};
+use async_task::Runnable;
+use futures_lite::future;
+
+use std::io;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::task::{Context, Poll};
+
+pub(crate) type Lock = ();
+
+/// The zombie process reaper.
+pub(crate) struct Reaper {
+    /// The channel for sending new runnables.
+    sender: Sender<Runnable>,
+
+    /// The channel for receiving new runnables.
+    recv: Receiver<Runnable>,
+
+    /// Number of zombie processes.
+    zombies: AtomicU64,
+}
+
+impl Reaper {
+    /// Create a new reaper.
+    pub(crate) fn new() -> Self {
+        let (sender, recv) = async_channel::unbounded();
+        Self {
+            sender,
+            recv,
+            zombies: AtomicU64::new(0),
+        }
+    }
+
+    /// "Lock" the driver thread.
+    ///
+    /// Since multiple threads can drive the reactor at once, there is no need to
+    /// actually lock anything. So this function only exists for symmetry.
+    pub(crate) async fn lock(&self) {}
+
+    /// Reap zombie processes forever.
+    pub(crate) async fn reap(&'static self, _: ()) -> ! {
+        loop {
+            // Fetch the next task.
+            let task = match self.recv.recv().await {
+                Ok(task) => task,
+                Err(_) => panic!("sender should never be closed"),
+            };
+
+            // Poll the task.
+            task.run();
+        }
+    }
+
+    /// Register a child into this reaper.
+    pub(crate) fn register(&'static self, child: std::process::Child) -> io::Result<ChildGuard> {
+        Ok(ChildGuard {
+            inner: Some(WaitableChild::new(child)?),
+        })
+    }
+
+    /// Wait for a child to complete.
+    pub(crate) async fn status(
+        &'static self,
+        child: &Mutex<crate::ChildGuard>,
+    ) -> io::Result<std::process::ExitStatus> {
+        future::poll_fn(|cx| {
+            // Lock the child and poll it once.
+            child
+                .lock()
+                .unwrap()
+                .inner
+                .inner
+                .as_mut()
+                .unwrap()
+                .poll_wait(cx)
+        })
+        .await
+    }
+
+    /// Do we have any registered zombie processes?
+    pub(crate) fn has_zombies(&'static self) -> bool {
+        self.zombies.load(Ordering::SeqCst) > 0
+    }
+}
+
+/// The wrapper around the child.
+pub(crate) struct ChildGuard {
+    inner: Option<WaitableChild>,
+}
+
+impl ChildGuard {
+    /// Get a mutable reference to the inner child.
+    pub(crate) fn get_mut(&mut self) -> &mut std::process::Child {
+        self.inner.as_mut().unwrap().get_mut()
+    }
+
+    /// Begin the reaping process for this child.
+    pub(crate) fn reap(&mut self, reaper: &'static Reaper) {
+        struct CallOnDrop<F: FnMut()>(F);
+
+        impl<F: FnMut()> Drop for CallOnDrop<F> {
+            fn drop(&mut self) {
+                (self.0)();
+            }
+        }
+
+        // Create a future for polling this child.
+        let future = {
+            let mut inner = self.inner.take().unwrap();
+            async move {
+                // Increment the zombie count.
+                reaper.zombies.fetch_add(1, Ordering::Relaxed);
+
+                // Decrement the zombie count once we are done.
+                let _guard = CallOnDrop(|| {
+                    reaper.zombies.fetch_sub(1, Ordering::SeqCst);
+                });
+
+                // Wait on this child forever.
+                let result = future::poll_fn(|cx| inner.poll_wait(cx)).await;
+                if let Err(e) = result {
+                    tracing::error!("error while polling zombie process: {}", e);
+                }
+            }
+        };
+
+        // Create a future for scheduling this future.
+        let schedule = move |runnable| {
+            reaper.sender.try_send(runnable).ok();
+        };
+
+        // Spawn the task and run it forever.
+        let (runnable, task) = async_task::spawn(future, schedule);
+        task.detach();
+        runnable.schedule();
+    }
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(any(
+        target_os = "linux",
+        target_os = "android"
+    ))] {
+        use async_io::Async;
+        use rustix::process;
+        use std::os::unix::io::OwnedFd;
+
+        /// Waitable version of `std::process::Child`
+        struct WaitableChild {
+            child: std::process::Child,
+            handle: Async<OwnedFd>,
+        }
+
+        impl WaitableChild {
+            fn new(child: std::process::Child) -> io::Result<Self> {
+                let pidfd = process::pidfd_open(
+                    process::Pid::from_child(&child),
+                    process::PidfdFlags::empty()
+                )?;
+
+                Ok(Self {
+                    child,
+                    handle: Async::new(pidfd)?
+                })
+            }
+
+            fn get_mut(&mut self) -> &mut std::process::Child {
+                &mut self.child
+            }
+
+            fn poll_wait(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<std::process::ExitStatus>> {
+                loop {
+                    if let Some(status) = self.child.try_wait()? {
+                        return Poll::Ready(Ok(status));
+                    }
+
+                    // Wait for us to become readable.
+                    futures_lite::ready!(self.handle.poll_readable(cx))?;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit adds a new backend for the process reaper. Rather than
waiting on a signal, it instead registers the process's pidfd into
async-io and waits on that instead.
    
I've coded this backend to also allow for other systems to be registered
here as well.

cc #49
