### PR TITLE
v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 2.2.0
+
+- Port Linux to a new backend that tries to use `pidfd` if it is available. (#68)
+
 # Version 2.1.0
 
 - Update `event-listener` to v5.1.0. (#67)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-process"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.1.0"
+version = "2.2.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- Port Linux to a new backend that tries to use `pidfd` if it is available. (#68)
