### PR TITLE
Add a test that sleeps

### DIFF
--- a/tests/sleep.rs
+++ b/tests/sleep.rs
@@ -16,7 +16,11 @@ fn unix_sleep() {
 #[test]
 fn windows_sleep() {
     block_on(async {
-        let status = Command::new("timeout").arg("5").status().await.unwrap();
+        let status = Command::new("ping")
+            .args(["-n", "5", "127.0.0.1"])
+            .status()
+            .await
+            .unwrap();
         assert!(status.success());
     });
 }

--- a/tests/sleep.rs
+++ b/tests/sleep.rs
@@ -1,0 +1,13 @@
+//! Sleep test.
+
+use async_process::Command;
+use futures_lite::future::block_on;
+
+#[cfg(unix)]
+#[test]
+fn unix_sleep() {
+    block_on(async {
+        let status = Command::new("sleep").arg("1").status().await.unwrap();
+        assert!(status.success());
+    });
+}

--- a/tests/sleep.rs
+++ b/tests/sleep.rs
@@ -11,3 +11,12 @@ fn unix_sleep() {
         assert!(status.success());
     });
 }
+
+#[cfg(windows)]
+#[test]
+fn windows_sleep() {
+    block_on(async {
+        let status = Command::new("timeout").arg("5").status().await.unwrap();
+        assert!(status.success());
+    });
+}


### PR DESCRIPTION
I think this catches errors in notification for the Linux backend.
