### PR TITLE
fix: use signal backend on android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,34 @@ jobs:
       - run: cargo test
         env:
           RUSTFLAGS: ${{ env.RUSTFLAGS }} --cfg async_process_force_signal_backend
+  
+  test-android:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [nightly, beta, stable]
+        target:
+          - aarch64-linux-android
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        # --no-self-update is necessary because the windows environment cannot self-update rustup.exe.
+        run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
+      - name: Install cross-compilation tools
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+      # On nightly and `-Z doctest-xcompile` is available,
+      # `$DOCTEST_XCOMPILE` is `-Zdoctest-xcompile`.
+      #
+      # On stable, `$DOCTEST_XCOMPILE` is not set.
+      # Once `-Z doctest-xcompile` is stabilized, the corresponding flag
+      # will be set to `$DOCTEST_XCOMPILE` (if it is available).
+      # - run: cargo test --verbose $DOCTEST_XCOMPILE
+      # workaround, 3 tests fail because they cant find /system/bin/sh
+      # in qemu
+      - run: cargo build --verbose
 
   msrv:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable]
+        rust: [nightly]
         target:
           - aarch64-linux-android
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ async-io = "2.1.0"
 async-signal = "0.2.3"
 rustix = { version = "0.38", default-features = false, features = ["std", "fs"] }
 
-[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 async-channel = "2.0.0"
 async-task = "4.7.0"
 
-[target.'cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))'.dependencies]
+[target.'cfg(all(unix, not(target_os = "linux")))'.dependencies]
 rustix = { version = "0.38", default-features = false, features = ["std", "fs", "process"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/src/reaper/mod.rs
+++ b/src/reaper/mod.rs
@@ -12,13 +12,13 @@
 #![allow(irrefutable_let_patterns)]
 
 /// Enable the waiting reaper.
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(target_os = "linux")]
 macro_rules! cfg_wait {
     ($($tt:tt)*) => {$($tt)*};
 }
 
 /// Enable the waiting reaper.
-#[cfg(not(any(target_os = "linux", target_os = "android")))]
+#[cfg(not(target_os = "linux"))]
 macro_rules! cfg_wait {
     ($($tt:tt)*) => {};
 }
@@ -41,7 +41,7 @@ use std::sync::Mutex;
 
 /// The underlying system reaper.
 pub(crate) enum Reaper {
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(target_os = "linux")]
     /// The reaper based on the wait backend.
     Wait(wait::Reaper),
 
@@ -51,7 +51,7 @@ pub(crate) enum Reaper {
 
 /// The wrapper around a child.
 pub(crate) enum ChildGuard {
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(target_os = "linux")]
     /// The child guard based on the wait backend.
     Wait(wait::ChildGuard),
 
@@ -61,7 +61,7 @@ pub(crate) enum ChildGuard {
 
 /// A lock on the reaper.
 pub(crate) enum Lock {
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(target_os = "linux")]
     /// The wait-based reaper needs no lock.
     Wait,
 

--- a/src/reaper/wait.rs
+++ b/src/reaper/wait.rs
@@ -69,7 +69,7 @@ impl Reaper {
             // Get the inner child value.
             let inner = match &mut child.inner {
                 super::ChildGuard::Wait(inner) => inner,
-                _ => unreachable!()
+                _ => unreachable!(),
             };
 
             // Poll for the next value.
@@ -112,7 +112,7 @@ impl ChildGuard {
                 // Wait on this child forever.
                 let result = future::poll_fn(|cx| inner.poll_wait(cx)).await;
                 if let Err(e) = result {
-                   tracing::error!("error while polling zombie process: {}", e);
+                    tracing::error!("error while polling zombie process: {}", e);
                 }
             }
         };
@@ -130,10 +130,7 @@ impl ChildGuard {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(any(
-        target_os = "linux",
-        target_os = "android"
-    ))] {
+    if #[cfg(target_os = "linux")] {
         use async_io::Async;
         use rustix::process;
         use std::os::unix::io::OwnedFd;


### PR DESCRIPTION
Rustix does not expose pidfd functions for android, so this
commit changes so that the signal backend is used on android.
The pidfd functions were introduced in Linux kernel 5.1, and
epoll integration were introduced in 5.3.

Android version 13, is the first version where all released
version of the Android common kernel is based on Linux kernel
5.4 or higher.
<https://source.android.com/docs/core/architecture/kernel/android-common>

Resolves Issue #79