### PR TITLE
Fix new clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ features = [
     "Win32_System_Threading",
 ]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(async_process_force_signal_backend)'] }
+
 [dev-dependencies]
 async-executor = "1.5.1"
 async-io = "2.1.0"

--- a/src/reaper/signal.rs
+++ b/src/reaper/signal.rs
@@ -48,7 +48,7 @@ impl Reaper {
             self.pipe.wait().await;
 
             // Notify all listeners waiting on the SIGCHLD event.
-            self.sigchld.notify(std::usize::MAX);
+            self.sigchld.notify(usize::MAX);
 
             // Reap zombie processes, but make sure we don't hold onto the lock for too long!
             let mut zombies = mem::take(&mut *self.zombies.lock().unwrap());
@@ -182,7 +182,7 @@ cfg_if::cfg_if! {
                     let reaper = match &crate::Reaper::get().sys {
                         super::Reaper::Signal(reaper) => reaper,
                     };
-                    
+
                     reaper.pipe.sender.try_send(()).ok();
                 }
 


### PR DESCRIPTION
- Indicate that `async_process_force_signal_backend` is an expected cfg
  predicate.
- Use `usize::MAX` instead of `std::usize::MAX`.
