### PR TITLE
v2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 2.2.3
+
+- Fix builds on Android by having Android unconditionally use the signal reaper
+  backend. (#80)
+
 # Version 2.2.2
 
 - Fix a typo in the docs for `ChildStdin`. (#76)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-process"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.2.2"
+version = "2.2.3"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- Fix builds on Android by having Android unconditionally use the signal reaper backend. (#80)
