### PR TITLE
Fix target-specific feature flags for rustix dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,11 @@ tracing = { version = "0.1.40", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 async-signal = "0.2.3"
-rustix = { version = "1.0", default-features = false, features = ["std", "fs"] }
+rustix = { version = "1.0", default-features = false, features = ["std", "fs", "process"] }
 
 [target.'cfg(any(windows, target_os = "linux"))'.dependencies]
 async-channel = "2.0.0"
 async-task = "4.7.0"
-
-[target.'cfg(all(unix, not(target_os = "linux")))'.dependencies]
-rustix = { version = "1.0", default-features = false, features = ["std", "fs", "process"] }
 
 [target.'cfg(windows)'.dependencies]
 blocking = "1.0.0"


### PR DESCRIPTION
The "rustix::process" module is only imported for `cfg(target_os = "linux")` in [Rust code](https://github.com/smol-rs/async-process/blob/v2.3.1/src/reaper/wait.rs#L137), but the "process" feature of rustix was only enabled if the target_os was *not* "linux", so the logic in Cargo.toml was reversed from what is actually needed.

This PR changes the target-specific dependency for rustix to only enable the "process" feature if the `target_os` is "linux", but not otherwise, which seems to have been the intended configuration all along.