### PR TITLE
Release 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 2.5.0
+
+- Bump MSRV to 1.71. (#106)
+- Add `Command::get_{args, envs, current_dir, program}` (#102)
+- Update to `windows-sys` v0.61. (#104)
+- Remove dependency on `async_lock` on Windows. (#103)
+
 # Version 2.4.0
 
 - Add a new optional `tracing` feature. When enabled, this feature adds logging

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-process"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.4.0"
+version = "2.5.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.71"


### PR DESCRIPTION
Changes:

- Bump MSRV to 1.71. (#106)
- Add `Command::get_{args, envs, current_dir, program}` (#102)
- Update to `windows-sys` v0.61. (#104)
- Remove dependency on `async_lock` on Windows. (#103)